### PR TITLE
Fixes mask not applying to icons' pixels against the artboard edge

### DIFF
--- a/src/providers/mask.js
+++ b/src/providers/mask.js
@@ -235,8 +235,10 @@ function applyMask(context, rootObject, params) {
   }
 
   const currentArtboardSize = rootObject.rect()
-  mask.setHeightRespectingProportions(currentArtboardSize.size.height)
-  mask.setWidthRespectingProportions(currentArtboardSize.size.width)
+  mask.setHeightRespectingProportions(currentArtboardSize.size.height + 2)
+  mask.setWidthRespectingProportions(currentArtboardSize.size.width + 2)
+  mask.frame().setX(-1)
+  mask.frame().setY(-1)
   mask.setName('🎨 color')
   rootObject.firstLayer().style().disableAllFills()
   rootObject.addLayers([mask])


### PR DESCRIPTION

<img width="618" alt="screenshot_199" src="https://user-images.githubusercontent.com/1865099/41505227-dd30d012-71b8-11e8-8a51-ad01bf97f4dc.png">

Icons that push right against the edge can have pixels that don't get colored by the mask.

By making the mask larger than the artboard, this problem goes away!